### PR TITLE
Adding repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "author": "Nicholas C. Zakas",
   "version": "0.2.0",
   "description": "A testing utility for ESLint",
+  "repository": "eslint/eslint-tester",
   "main": "lib/eslint-tester.js",
   "scripts": {
     "test": "node Makefile.js test",


### PR DESCRIPTION
Now the repo URL and stuff will show up in [npmjs.org](https://www.npmjs.org/package/eslint-tester) and `npm bugs eslint-tester` should work.
