### PR TITLE
Default configuration

### DIFF
--- a/lib/eslint-tester.js
+++ b/lib/eslint-tester.js
@@ -45,7 +45,27 @@
 
 var assert = require("chai").assert,
     util = require("util"),
-    path = require("path");
+    path = require("path"),
+    merge = require("lodash.merge"),
+    omit = require("lodash.omit"),
+    clone = require("lodash.clonedeep");
+
+//------------------------------------------------------------------------------
+// Private Members
+//------------------------------------------------------------------------------
+// testerDefaultConfig must not be modified as it allows to reset the tester to
+// the initial default configuration
+var testerDefaultConfig = { rules: {} };
+var defaultConfig = { rules: {} };
+// List every parameters possible on a test case that are not related to eslint
+// configuration
+var eslintTesterParameters = [
+    "code",
+    "filename",
+    "options",
+    "args",
+    "errors"
+];
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -54,16 +74,59 @@ var assert = require("chai").assert,
 /**
  * Creates a new instance of ESLintTester.
  * @param {ESLint} eslint The ESLint instance to use.
+ * @param {Object} Optional, extra configuration for the tester
  * @constructor
  */
-function ESLintTester(eslint) {
+function ESLintTester(eslint, testerConfig) {
 
     /**
      * The internal linter to use.
      * @type {ESLint}
      */
     this.eslint = eslint;
+    /**
+     * The configuration to use for this tester. Combination of the tester
+     * configuration and the default configuration.
+     * @type {Object}
+     */
+    this.testerConfig = merge(
+        // we have to clone because merge uses the object on the left for
+        // recipient
+        clone(defaultConfig),
+        testerConfig
+    );
 }
+
+/**
+ * Set the configuration to use for all future tests
+ * @param {Object} the configuration to use.
+ * @returns {void}
+ */
+ESLintTester.setDefaultConfig = function(config) {
+    if(typeof config !== "object") {
+        throw new Error("ESLintTester.setDefaultConfig: config must be an object");
+    }
+    defaultConfig = config;
+    // Make sure the rules object exists since it is assumed to exist later
+    defaultConfig.rules = defaultConfig.rules || {};
+};
+
+/**
+ * Get the current configuration used for all tests
+ * @returns {Object} the current configuration
+ */
+ESLintTester.getDefaultConfig = function() {
+    return defaultConfig;
+};
+
+/**
+ * Reset the configuration to the initial configuration of the tester removing
+ * any changes made until now.
+ * @returns {void}
+ */
+ESLintTester.resetDefaultConfig = function() {
+    defaultConfig = clone(testerDefaultConfig);
+};
 
 ESLintTester.prototype = {
 
@@ -76,31 +139,33 @@ ESLintTester.prototype = {
     addRuleTest: function(rulePath, test) {
 
         var eslint = this.eslint,
+            testerConfig = this.testerConfig,
             result = {},
             ruleName = path.basename(rulePath);
 
         function runRuleForItem(ruleName, item) {
-            var config = { rules: {} },
-                code = item.code ? item.code : item,
+            var config = clone(testerConfig),
+                code,
                 filename;
 
-            if (item.globals || item.global) {
-                config.global = item.globals ? item.globals : item.global;
+            if (typeof item === "string") {
+                code = item;
+            } else {
+                code = item.code;
+                // Assumes everything on the item is a config except for the
+                // parameters used by this tester
+                var itemConfig = omit(item, eslintTesterParameters);
+                // Create the config object from the tester config and this item
+                // specific configurations.
+                config = merge(
+                    config,
+                    itemConfig
+                );
             }
 
             if (item.filename) {
                 filename = item.filename;
             }
-
-            if (item.parser) {
-                config.parser = item.parser;
-            }
-
-            if (item.ecmaFeatures) {
-                config.ecmaFeatures = item.ecmaFeatures;
-            }
-
-            config.settings = item.settings;
 
             if (item.options) {
                 var options = item.options.concat();
@@ -128,7 +193,7 @@ ESLintTester.prototype = {
             var messages = runRuleForItem(ruleName, item);
 
             if (typeof item.errors === "number") {
-                assert.equal(messages.length, item.errors,  util.format("Should have %d errors but had %d: %s",
+                assert.equal(messages.length, item.errors, util.format("Should have %d errors but had %d: %s",
                     item.errors, messages.length, util.inspect(messages)));
             } else {
                 assert.equal(messages.length, item.errors.length,

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   "license": "MIT",
   "dependencies": {
     "chai": "^1.10.0",
+    "lodash.clonedeep": "^3.0.0",
+    "lodash.merge": "^3.1.0",
+    "lodash.omit": "^3.1.0",
     "mocha": "~1.17.1"
   },
   "devDependencies": {

--- a/tests/lib/eslint-tester.js
+++ b/tests/lib/eslint-tester.js
@@ -50,6 +50,7 @@ describe("ESLintTester", function() {
     var eslintTester;
 
     beforeEach(function() {
+        ESLintTester.resetDefaultConfig();
         eslintTester = new ESLintTester(eslint);
     });
 
@@ -401,6 +402,70 @@ describe("ESLintTester", function() {
                 ]
             });
         }, /^Each rule should have at least one invalid test/);
+    });
+
+    it("should pass-through the tester config to the to rule", function() {
+        eslintTester = new ESLintTester(eslint, {
+            global: { test: true }
+        });
+        assert.doesNotThrow(function() {
+            eslintTester.addRuleTest("tests/fixtures/no-test-global", {
+                valid: [
+                    "var test = 'foo'",
+                    "var test2 = test"
+                ],
+                invalid: [ { code: "bar", errors: 1, global: { foo: true } } ]
+            });
+        });
+    });
+
+    it("should correctly set the global configuration", function() {
+        var config = { global: { test: true } };
+        ESLintTester.setDefaultConfig(config);
+        assert(
+            ESLintTester.getDefaultConfig().global.test,
+            "The default config object is incorrect"
+        );
+    });
+
+    it("should correctly reset the global configuration", function() {
+        var config = { global: { test: true } };
+        ESLintTester.setDefaultConfig(config);
+        ESLintTester.resetDefaultConfig();
+        assert.deepEqual(
+            ESLintTester.getDefaultConfig(),
+            { rules: {} },
+            "The default configuration has not reset correctly"
+        );
+    });
+
+    it("should enforce the global configuration to be an object", function() {
+        function setConfig(config) {
+            return function() {
+                ESLintTester.setDefaultConfig(config);
+            };
+        }
+        assert.throw(setConfig());
+        assert.throw(setConfig(1));
+        assert.throw(setConfig(3.14));
+        assert.throw(setConfig("foo"));
+        assert.throw(setConfig(null));
+        assert.throw(setConfig(true));
+    });
+
+    it("should pass-through the global config to the tester then to the to rule", function() {
+        var config = { global: { test: true } };
+        ESLintTester.setDefaultConfig(config);
+        eslintTester = new ESLintTester(eslint);
+        assert.doesNotThrow(function() {
+            eslintTester.addRuleTest("tests/fixtures/no-test-global", {
+                valid: [
+                    "var test = 'foo'",
+                    "var test2 = test"
+                ],
+                invalid: [ { code: "bar", errors: 1, global: { foo: true } } ]
+            });
+        });
     });
 
 });


### PR DESCRIPTION
Added the option to set global and tester level configuration. Rules configuration result in `global <= tester <= test case`. (fixes #19)

I am not sure if this implementation and usage is acceptable for you, but I figured I would give it a shot and then we can discuss to improve it.